### PR TITLE
fix: date objects are not returned from `map`

### DIFF
--- a/src/lib/map.test.ts
+++ b/src/lib/map.test.ts
@@ -54,4 +54,10 @@ describe('Map', () => {
 
 		expect(map(input, config)).toEqual(expected)
 	})
+
+	it('should map a date object', () => {
+		const input = { date: new Date(1, 1, 1) }
+		const config: MapperConfig<typeof input> = { date: (d) => d.date }
+		expect(map(input, config)).toStrictEqual({ date: new Date(1, 1, 1) })
+	})
 })

--- a/src/lib/map.ts
+++ b/src/lib/map.ts
@@ -2,6 +2,7 @@ import set from 'set-value'
 import type { MapperConfig, MapperOptions } from './types'
 import { wrapProperty } from './utils/wrapProperty'
 import * as structure from './structure'
+import { isPlainObject } from './utils/isPlainObject'
 
 export function map<T>(data: T, config: MapperConfig<T>, options?: MapperOptions) {
 	const mapped: Record<keyof typeof config, any> = {}
@@ -21,7 +22,7 @@ export function map<T>(data: T, config: MapperConfig<T>, options?: MapperOptions
 		}
 
 		const value = property.value(data)
-		if (Array.isArray(value) || typeof value === 'object') {
+		if (Array.isArray(value) || isPlainObject(value)) {
 			const innerKeys = typeof value === 'object' ? Object.keys(value) : value
 			const structureFn = property.options?.structure ?? structure.Keep
 			for (let i = 0; i < innerKeys.length; i += 1) {

--- a/src/lib/utils/isPlainObject.test.ts
+++ b/src/lib/utils/isPlainObject.test.ts
@@ -1,0 +1,15 @@
+import { isPlainObject } from './isPlainObject'
+
+describe('isPlainObject', () => {
+	it('should return true for plain objects', () => {
+		const input = { test: true }
+		expect(isPlainObject(input)).toBeTruthy()
+	})
+
+	it('should return false for non-plain objects', () => {
+		const date = new Date()
+		const arr = [1, 2, 3, 4]
+		expect(isPlainObject(date)).toBeFalsy()
+		expect(isPlainObject(arr)).toBeFalsy()
+	})
+})

--- a/src/lib/utils/isPlainObject.ts
+++ b/src/lib/utils/isPlainObject.ts
@@ -1,0 +1,3 @@
+export function isPlainObject(target: unknown) {
+	return typeof target === 'object' && Object.prototype.toString.call(target) === '[object Object]'
+}


### PR DESCRIPTION
This fixes the invalid behavior where all object types where destructured.

If you want to map a non-plain object and use the structure functionality, you should explicitly set the value function to return a plain object e.g.

```ts
{
  date: (d) => ({ ...d.date })
}
```